### PR TITLE
Cleanup package.json and add release workflow

### DIFF
--- a/.github/workflows/refapps-release.yml
+++ b/.github/workflows/refapps-release.yml
@@ -1,0 +1,28 @@
+name: Make a refapps release with compiled package archives
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-release:
+    name: Build refapps and make a release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build reference apps
+        run: yarn build:refapps
+
+      - name: Create a release and upload artifacts
+        run: >
+          gh release create ${{ github.ref }}
+          packages/reference-apps/*.tar.gz
+          python/reference-apps/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.SCRAMJET_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+Scramjet reference apps
+=======================
+
+You can download apps from the [releases page](https://github.com/scramjetorg/reference-apps/releases).
+
+Initial history was imported from https://github.com/scramjetorg/transform-hub repository.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@scramjet/transform-hub",
+  "name": "@scramjet/reference-apps",
   "version": "0.22.0",
   "private": true,
-  "description": "A development repo for Scramjet Transform Hub, a container supervisor that allows deployment, execution and monitoring of any application based on a simple interface.",
+  "description": "A collection of reference applications for Scramjet platform.",
   "main": "index.js",
   "bic": {
     "only": [
@@ -16,102 +16,31 @@
     "scramjet-transform-hub": "dist/sth/bin/hub.js"
   },
   "scripts": {
-    "build": "yarn build:all",
-    "build:packages-esbuild": "lerna run build:esbuild",
-    "build:all": "yarn build:packages && yarn build:refapps && yarn build:docker",
+    "build": "yarn build:refapps",
     "prebuild:refapps": "scripts/build-all.js --dirs packages/reference-apps/* --config-name=tsconfig.json",
     "build:refapps": "LOCAL_PACKAGES=true lerna run build:refapps:only",
-    "postbuild:refapps": "LOCAL_PACKAGES=true lerna run postbuild:refapps",
-    "prebuild:packages": "scripts/build-all.js --dirs packages/* --config-name=tsconfig.build.json",
-    "build:packages": "LOCAL_PACKAGES=true lerna run build:only && LOCAL_PACKAGES=true lerna run postbuild",
-    "build:all-packages": "LOCAL_PACKAGES=true lerna run build && LOCAL_PACKAGES=true lerna run build:refapps",
-    "build:docker": "lerna run build:docker",
-    "build:readme": "node ./scripts/mk-readme",
-    "build:docs": "lerna run build:docs",
-    "build:all-docs": "node ./scripts/mk-readme && lerna run build:docs",
-    "pack-one-app": "([ -n \"$APPNAME\" ] || ( echo 'usage: APPNAME=@scramjet/reference-transform-1-seq yarn pack-one-app' ; exit 1 ) ) && yarn build --scope=$APPNAME && yarn prepack --scope=$APPNAME",
-    "clean:root": "rm -rf ./dist/",
-    "clean:modules": "find -name node_modules -or -name __pypackages__ -prune -exec rm -rf {} ';' 2> /dev/null",
-    "clean": "lerna run clean && yarn clean:root",
-    "cloc": "cloc . --fullpath --include-lang TypeScript --not-match-d \"(node_modules|test|dist|bdd)\" --by-percent cm",
-    "prepack": "yarn pack:pre",
-    "pack:pre": "LOCAL_PACKAGES=true lerna run prepack",
-    "pack:pub": "yarn clean:root && FLAT_PACKAGES=true MAKE_PUBLIC=true NO_INSTALL=true lerna run prepack",
-    "packseq": "lerna run packseq",
-    "publish:dist": "find dist/ -iname package.json -not -wholename '*node_modules*' -execdir yarn publish --no-git-tag-version --non-interactive \\;",
-    "lint": "eslint . --ext .ts --cache --cache-strategy=content --cache-location=/tmp/.eslintcache_scramjet-csi",
-    "lint:uncached": "rm /tmp/.eslintcache_scramjet-csi && yarn lint",
-    "lint:dedupe": "scripts/dedupe.js",
-    "start": "node dist/sth/bin/hub.js",
-    "start:dev": "ts-node packages/sth/src/bin/hub.ts",
-    "install:clean": "yarn clean && yarn clean:modules && yarn install",
-    "postinstall": "lerna link",
-    "prepare": "npx husky install",
-    "test": "lerna run test",
-    "test:packages": "lerna run test",
-    "test:packages-no-concurrent": "lerna run test --concurrency=1",
-    "test:bdd-ci": "yarn --cwd=./bdd run test:bdd --format=@cucumber/pretty-formatter --tags=@ci --tags=\"not @starts-host\"",
-    "test:bdd-ci-py": "yarn --cwd=./packages/api-client-py run test:bdd -t @ci",
-    "test:bdd-cli": "yarn --cwd=./bdd run test:bdd --format=@cucumber/pretty-formatter --tags=@cli",
-    "test:bdd-ci-no-host": "NO_HOST=true yarn --cwd=./bdd run test:bdd --format=@cucumber/pretty-formatter --tags=@ci --tags=\"@starts-host\"",
-    "test:bdd": "yarn --cwd=./bdd run test:bdd --fail-fast",
-    "test:bdd-ci-no-docker": "RUNTIME_ADAPTER=process yarn test:bdd-ci --tags=\"not @docker-specific\"",
-    "test:bdd-ci-no-host-no-docker": "RUNTIME_ADAPTER=process yarn test:bdd-ci-no-host --tags=\"not @docker-specific\"",
-    "prebump:packages": "NEXT_VER=$(npx semver -i ${VERSION_LEVEL:-prerelease} $(jq -r .version < package.json)) && git diff --exit-code --quiet && yarn bump:images && lerna version -y --force-publish --no-git-tag-version ${NEXT_VER} && git add .",
-    "bump:packages": "NEXT_VER=$(npx semver -i ${VERSION_LEVEL:-prerelease} $(jq -r .version < package.json)) && yarn version --new-version ${NEXT_VER}",
-    "bump:images": "./scripts/bump_docker_images.sh",
-    "bump:version:minor": "VERSION_LEVEL=minor yarn bump:packages",
-    "bump:version:patch": "VERSION_LEVEL=patch yarn bump:packages",
-    "bump:version": "yarn bump:packages --no-git-tag-version",
-    "bump:postversion": "yarn pack:pub && yarn publish:dist && git push --follow-tags",
-    "align": "syncpack fix-mismatches --source all-deps/package.json --source bdd/package.json --source='packages/**(!node_modules)/package.json' --source='packages/reference-apps/**(!node_modules)/package.json' --source='template/package.json'",
-    "upgrade:all": "node scripts/deps-update.js && yarn align && rm -rf ./all-deps && yarn install",
-    "savehash": "LOCAL_PACKAGES=true lerna run savehash"
+    "postbuild:refapps": "LOCAL_PACKAGES=true lerna run postbuild:refapps"
   },
   "author": "Scramjet <open-source@scramjet.org>",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scramjetorg/transform-hub.git"
+    "url": "https://github.com/scramjetorg/reference-apps.git"
   },
   "devDependencies": {
-    "@types/node": "15.12.5",
-    "@typescript-eslint/eslint-plugin": "^4.27.0",
-    "@typescript-eslint/parser": "^4.27.0",
-    "build-if-changed": "^1.5.5",
-    "cloc": "^2.8.0",
-    "esbuild": "^0.14.13",
-    "eslint": "^7.29.0",
-    "eslint-plugin-import": "^2.23.3",
-    "eslint-to-editorconfig": "^2.0.0",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
-    "globrex": "^0.1.2",
-    "husky": "^6.0.0",
     "lerna": "^4.0.0",
-    "semver": "^7.3.5",
-    "syncpack": "^5.7.11",
     "tar": "^6.1.0",
-    "toposort": "^2.0.2",
-    "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
     "typescript": "^4.3.4"
   },
   "workspaces": {
     "packages": [
-      "packages/*",
       "packages/reference-apps/*",
-      "python/reference-apps/*",
-      "bdd"
+      "python/reference-apps/*"
     ]
   },
-  "husky": {
-    "hooks": {
-      "pre-push": "yarn lint"
-    }
-  },
   "dependencies": {
-    "minimist": "^1.2.6",
-    "scramjet": "^4.36.0"
+    "minimist": "^1.2.6"
   }
 }


### PR DESCRIPTION
Refapps code was imported from transform-hub repo in commit 750bc375748e198d4d677284c90d9ecd27912a0e. This PR is about configuring workflow for building it etc.

* package.json contains a lot of unnecessary stuff from transform-hub repo - remove it.
* add github workflow that will create a release with compiled refapps whenever a new tag is pushed.