### PR TITLE
Fix endless-names-output to allow to provide 1 name

### DIFF
--- a/js/endless-names-output/index.ts
+++ b/js/endless-names-output/index.ts
@@ -25,7 +25,7 @@ export = async function(_stream, max = 10) {
 
         cnt++;
 
-        if (max && cnt > max) {
+        if (cnt > max) {
             clearInterval(interval);
             ps.end();
         }


### PR DESCRIPTION
when passing argument 0 to endless-names-output the if condition equal to false and 2 names are generated