### PR TITLE
Fix/git error handling

### DIFF
--- a/js/git-read-issues/README.md
+++ b/js/git-read-issues/README.md
@@ -4,7 +4,10 @@ This sequence reads all of the github issues for a given repositories.
 
 It prepares the data in a format that will be used in [clickup-add-issues](https://github.com/scramjetorg/reference-apps/tree/main/js/clickup-add-issues) and send it to a topic.
 
+This sequence validates if the body of issue is empty, if so issue will be skiped.
+
 > ! All issues that has been read by this sequence will be labeled as read in a github
+
 
 ## Setup
 

--- a/js/git-read-issues/src/githubClient.ts
+++ b/js/git-read-issues/src/githubClient.ts
@@ -11,9 +11,9 @@ export class GithubClient {
     owner: string = "";
     apiKey: string;
     octokit: Octokit;
-    logger:IObjectLogger;
+    logger: IObjectLogger;
 
-    constructor(apiKey: string, logger:IObjectLogger) {
+    constructor(apiKey: string, logger: IObjectLogger) {
         this.apiKey = apiKey;
         this.logger = logger;
         this.octokit = new Octokit({

--- a/js/git-read-issues/src/githubClient.ts
+++ b/js/git-read-issues/src/githubClient.ts
@@ -49,9 +49,7 @@ export class GithubClient {
     }
 
     public async search(repo:{owner:string, repo:string}): Promise<Issue[]> {
-
         this.logger.info(`checking repo: ${repo.owner}/${repo.repo} ...`);
-
         this.owner = repo.owner;
         this.repo = repo.repo;
         const issuesArr: Issue[] = [];
@@ -104,9 +102,5 @@ export class GithubClient {
                 }
             }
         }));
-                }
-            });
-            return issuesArr;
-        });
     }
 }

--- a/js/git-read-issues/src/githubClient.ts
+++ b/js/git-read-issues/src/githubClient.ts
@@ -55,9 +55,9 @@ export class GithubClient {
         const issuesArr: Issue[] = [];
 
         return this.gitHubFilter().then(async (result) => {
-            await result.map(async (e) => {
+            result.map(async (e) => {
                 if (typeof e.body === "string") {
-                    this.logger.info(`found new issue ${e.title} in: ${this.repo}`);
+                    this.logger.info(`found new issue "${e.title}" in: ${this.repo}`);
                     const entry = new Issue(e.number, e.title, e.body, this.repo, e.labels, this.owner);
 
                     issuesArr.push(entry);

--- a/js/git-read-issues/src/githubClient.ts
+++ b/js/git-read-issues/src/githubClient.ts
@@ -1,70 +1,106 @@
+/* eslint-disable no-console */
 import { Octokit } from "octokit";
-import { ListUserReposResponse } from "./types/types";
 import { Issue } from "./issue";
+import { IObjectLogger } from "@scramjet/types/object-logger";
+import * as ghSettings from "./ghdata.json";
 
 const readLabel = "read";
 
 export class GithubClient {
-    repo: string;
-    owner: string;
+    repo: string = "";
+    owner: string = "";
     apiKey: string;
     octokit: Octokit;
+    logger:IObjectLogger;
 
-    constructor(settings: { repo: string; owner: string }, apiKey: string) {
-        this.repo = settings.repo;
-        this.owner = settings.owner;
+    constructor(apiKey: string, logger:IObjectLogger) {
         this.apiKey = apiKey;
+        this.logger = logger;
         this.octokit = new Octokit({
-            auth: apiKey
+            auth: apiKey,
+            log: console
         });
     }
+    setRepo(repo: { owner:string, repo:string }) {
+        this.owner = repo.owner;
+        this.repo = repo.repo;
+    }
 
-    gitRequestPromise(): Promise<ListUserReposResponse> {
-        return this.octokit.rest.issues.listForRepo({
+    private async gitHubFilter() {
+        const res = await this.octokit.rest.issues.listForRepo({
             owner: this.owner,
             repo: this.repo,
             state: "open"
         });
+
+        return res.data.filter(
+            (elem) => {
+                let hasReadLabel = false;
+
+                elem.labels.forEach((e) => {
+                    if (typeof e !== "string" && "name" in e && e.name === "read") {
+                        hasReadLabel = true;
+                    }
+                });
+
+                return !hasReadLabel;
+            }
+        );
     }
 
-    async gitLabel() {
-        const gitRequestResponse: ListUserReposResponse = await this.gitRequestPromise();
+    public async search(repo:{owner:string, repo:string}): Promise<Issue[]> {
+        this.logger.info(`checking repo: ${repo.owner}/${repo.repo} ...`);
+        this.owner = repo.owner;
+        this.repo = repo.repo;
+        const issuesArr: Issue[] = [];
 
-        gitRequestResponse.data.forEach(async (e:any) => {
-            await this.octokit.rest.issues.addLabels({
-                owner: this.owner,
-                repo: this.repo,
-                issue_number: e.number,
-                labels: [readLabel]
-            });
-        });
-
-        return gitRequestResponse.data;
-    }
-
-    async gitHubFilter() {
-        return await this.gitLabel().then((res) => {
-            const result = res.filter(
-                (elem: any) => !elem.labels.filter((e: any) => typeof e !== "string" && "name" in e && e.name === "read").length
-            );
-
-            return result;
-        });
-    }
-
-    async search(): Promise<Array<Issue>> {
-        const issuesArr: Array<Issue> = [];
-
-        await this.gitHubFilter().then((result) =>
-            result.map((e: any) => {
+        return this.gitHubFilter().then(async (result) => {
+            await result.map(async (e) => {
                 if (typeof e.body === "string") {
+                    this.logger.info(`found new issue ${e.title} in: ${this.repo}`);
                     const entry = new Issue(e.number, e.title, e.body, this.repo, e.labels, this.owner);
 
                     issuesArr.push(entry);
-                }
-            })
-        );
 
-        return issuesArr;
+                    await this.octokit.rest.issues.addLabels({
+                        owner: this.owner,
+                        repo: this.repo,
+                        issue_number: e.number,
+                        labels: [readLabel]
+                    });
+                } else {
+                    this.logger.info("found issue but its body was empty", e.title);
+                }
+            });
+
+            return issuesArr;
+        });
+    }
+    private async handShakeRequest(repo: { owner:string, repo:string }) {
+        const account = await this.octokit.rest.users.getAuthenticated();
+
+        if (account.status !== 200) {
+            throw new Error("unable to get user info");
+        } else {
+            this.logger.info(`authenticated to github as ${account.data.login}`);
+        }
+
+        return this.octokit.rest.repos.get({
+            owner: repo.owner,
+            repo: repo.repo
+        });
+    }
+    public async handShake(): Promise<void[]> {
+        return Promise.all(ghSettings.repos.map(async (e) => {
+            try {
+                await this.handShakeRequest(e);
+            } catch (error:any) {
+                if (error.status && error.response) {
+                    this.logger.error(`got status: ${error.status} from: ${error.response.url}`);
+                } else {
+                    this.logger.error("handshake error", error);
+                }
+            }
+        }));
     }
 }

--- a/js/git-read-issues/src/githubClient.ts
+++ b/js/git-read-issues/src/githubClient.ts
@@ -52,7 +52,6 @@ export class GithubClient {
 
         this.logger.info(`checking repo: ${repo.owner}/${repo.repo} ...`);
 
-
         this.owner = repo.owner;
         this.repo = repo.repo;
         const issuesArr: Issue[] = [];

--- a/js/git-read-issues/src/index.ts
+++ b/js/git-read-issues/src/index.ts
@@ -6,7 +6,7 @@ import { PassThrough } from "stream";
 
 function labelHelper(labels: any[], repo: string): Array<string> {
     return labels
-        .reduce((acc, c) => c !== "read" && c.name !== "read" ? acc.concat([c.name]) : acc, [])
+        .filter(label => label.name === "read" || label === "read")
         .concat([repo]);
 }
 


### PR DESCRIPTION
To test sequence: change data in ghdata.json then Get Github API token with a privileges to read/add issue in a given repo.
To start: 
`npm run build`
`si seq deploy dist --args '["API-KEY"]'
`
After running the sequence you should see all of your github issues marked as read and available in topic as issue.
To check topic:
`si topic get issue`
Expected output on successful request:
![obraz](https://github.com/scramjetorg/reference-apps/assets/53794300/72b47424-92c1-4af8-b3eb-60ae52358b85)

